### PR TITLE
Set move_group capabilities by checking the existence of 'capabilities' key in move_group_capabilities  dict

### DIFF
--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -196,12 +196,15 @@ def generate_move_group_launch(moveit_config):
     ld.add_action(
         DeclareBooleanLaunchArg("publish_monitored_planning_scene", default_value=True)
     )
-    # load non-default MoveGroup capabilities (space separated)
+
+    capabilities = moveit_config.move_group_capabilities
+    if "capabilities" in moveit_config.move_group_capabilities:
+        capabilities = moveit_config.move_group_capabilities["capabilities"]
     ld.add_action(
         DeclareLaunchArgument(
             "capabilities",
-            default_value=moveit_config.move_group_capabilities["capabilities"],
-        )
+            default_value=capabilities,
+       )
     )
     # inhibit these default MoveGroup capabilities (space separated)
     ld.add_action(DeclareLaunchArgument("disable_capabilities", default_value=""))

--- a/moveit_configs_utils/moveit_configs_utils/launches.py
+++ b/moveit_configs_utils/moveit_configs_utils/launches.py
@@ -204,7 +204,7 @@ def generate_move_group_launch(moveit_config):
         DeclareLaunchArgument(
             "capabilities",
             default_value=capabilities,
-       )
+        )
     )
     # inhibit these default MoveGroup capabilities (space separated)
     ld.add_action(DeclareLaunchArgument("disable_capabilities", default_value=""))


### PR DESCRIPTION
### Description

I encountered this error `[ERROR] [launch]: Caught exception in launch (see debug for traceback): 'capabilities'` mentioned in [#2734](https://github.com/moveit/moveit2/issues/2734)


Now capabilities is set by checking if the key `capabilities` in `move_group_capabilities` dict exists or not as it might come in handy if I'm going to use MTC as explained in the [PR comment](https://github.com/moveit/moveit2/pull/2587#issue-2031564363) that passed those capabilities to `launches.py`

